### PR TITLE
fixed wrong require

### DIFF
--- a/src/dk/cst/tf_idf.clj
+++ b/src/dk/cst/tf_idf.clj
@@ -1,7 +1,7 @@
 (ns dk.cst.tf-idf
   "A reasonably performant TF-IDF implementation."
   (:require [clojure.string :as str]
-            [clojure.java.math :as math]))
+            [clojure.math :as math]))
 
 ;; Should do a decent job with most Latin scripts.
 (def space+punctuation


### PR DESCRIPTION
The require for the math namespace should be `clojure.math`

